### PR TITLE
patterns: Require sailfish-fpd

### DIFF
--- a/patterns/patterns-sailfish-device-adaptation-pdx235.inc
+++ b/patterns/patterns-sailfish-device-adaptation-pdx235.inc
@@ -60,8 +60,8 @@ Requires: usb-moded
 Requires: rfkill
 
 # enable device lock and allow to select untrusted software
-#Requires: sailfish-devicelock-fpd
-Requires: jolla-devicelock-daemon-encsfa
+Requires: sailfish-devicelock-fpd
+#Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption


### PR DESCRIPTION
As sailfish-devicelock-fpd no longer explicitly requires sailfish-fpd, it needs to be pulled in via patterns.

[patterns] Require sailfish-fpd. JB#62474