### PR TITLE
patterns: Add missing Obsoletes for jolla-devicelock-daemon-encsfa

### DIFF
--- a/patterns/patterns-sailfish-device-adaptation-pdx235.inc
+++ b/patterns/patterns-sailfish-device-adaptation-pdx235.inc
@@ -62,6 +62,7 @@ Requires: rfkill
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
 #Requires: sailfish-fpd
+Obsoletes: jolla-devicelock-daemon-encsfa
 
 # Enable home encryption
 Requires: sailfish-device-encryption


### PR DESCRIPTION
Needed to prevent upgrades from breaking.

[patterns] Add missing Obsoletes for jolla-devicelock-daemon-encsfa. JB#62474